### PR TITLE
156 /redesign maker UI redesign

### DIFF
--- a/src/pages/MakerPage/MainPanel/PromptEditor.jsx
+++ b/src/pages/MakerPage/MainPanel/PromptEditor.jsx
@@ -261,8 +261,8 @@ const FakePlaceholder = styled.div`
   color: #bcbcbc;
   pointer-events: none; /* 중요: 이 요소가 클릭 이벤트를 가로채지 않도록 설정 */
   font-family: "Pretendard Variable", sans-serif;
-  line-height: 1.5;
-  font-size: 1.4375rem;
+  line-height: 1.625rem;
+  font-size: 1.25rem;
   p {
     margin: 0; /* p 태그의 기본 마진 제거 */
   }
@@ -277,10 +277,10 @@ const EditorTextarea = styled.textarea`
   width: 100%;
   height: 100%;
   font-family: "Pretendard Variable", sans-serif;
-  font-size: 1.44rem;
+  font-size: 1.25rem;
   font-weight: 400;
   color: ${(props) => (props.$shouldHideText ? "transparent" : "#001e40")};
-  line-height: 1.5;
+  line-height: 1.625rem;
   background: transparent; /* 중요: FakePlaceholder가 비쳐 보이도록 배경을 투명하게 */
   border: none;
   outline: none;
@@ -308,10 +308,10 @@ const SelectionOverlay = styled.div`
   width: 100%;
   height: 100%;
   font-family: "Pretendard Variable", sans-serif;
-  font-size: 1.44rem;
+  font-size: 1.25rem;
   font-weight: 400;
   color: #001e40;
-  line-height: 1.5;
+  line-height: 1.625rem;
   padding: 1rem 0;
   pointer-events: none;
   white-space: pre-wrap;
@@ -330,10 +330,10 @@ const TextOverlay = styled.div`
   width: 100%;
   height: 100%;
   font-family: "Pretendard Variable", sans-serif;
-  font-size: 1.44rem;
+  font-size: 1.25rem;
   font-weight: 400;
   color: #001e40;
-  line-height: 1.5;
+  line-height: 1.625rem;
   padding: 1rem 0;
   pointer-events: none;
   white-space: pre-wrap;

--- a/src/pages/MakerPage/SidePanel/PromptHub/PromptCard.jsx
+++ b/src/pages/MakerPage/SidePanel/PromptHub/PromptCard.jsx
@@ -1,7 +1,5 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "styled-components";
-import heartIcon from "../../assets/heartIcon.svg";
-import colorHeartIcon from "../../assets/colorHeartIcon.svg";
 import copyIcon from "../../assets/copyIcon.svg";
 
 export default function PromptCard({
@@ -13,13 +11,6 @@ export default function PromptCard({
   backgroundImage = "",
   onClick,
 }) {
-  const [isHeartClicked, setIsHeartClicked] = useState(false);
-
-  const handleHeartClick = (event) => {
-    event.stopPropagation();
-    setIsHeartClicked((prev) => !prev);
-  };
-
   const handleCopyClick = (event) => {
     event.stopPropagation();
     console.log("복사 버튼 클릭");
@@ -43,32 +34,22 @@ export default function PromptCard({
         {subtitle}
       </CardSubTitle>
       <ButtonSection>
-        <HeartIcon
-          src={isHeartClicked ? colorHeartIcon : heartIcon}
-          onClick={handleHeartClick}
-        />
         <CopyIcon src={copyIcon} onClick={handleCopyClick} />
       </ButtonSection>
     </PromptCardContainer>
   );
 }
 
-const HeartIcon = styled.img`
+const CopyIcon = styled.img`
   width: 1.75rem;
   height: 1.75rem;
+  margin-left: 0.37rem;
   cursor: pointer;
   transition: opacity 0.2s ease;
 
   &:hover {
     opacity: 0.8;
   }
-`;
-
-const CopyIcon = styled.img`
-  width: 1.75rem;
-  height: 1.75rem;
-  margin-left: 0.37rem;
-  cursor: pointer;
 `;
 
 const ButtonSection = styled.div`
@@ -102,27 +83,37 @@ const PromptAiName = styled.div`
 const PromptCardContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  padding: 0.94rem 1.19rem;
+  padding: 0.94rem 1.56rem;
   width: 18rem;
   height: 10rem;
-  aspect-ratio: 2 / 1;
+  aspect-ratio: 2/1;
   border-radius: 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  position: relative;
   background: ${({ backgroundImage }) =>
     backgroundImage
       ? `url(${backgroundImage}) center / cover no-repeat`
-      : `#dbf5ff;`};
+      : `#DBF5FF`};
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
   outline: none;
 
-  &:hover {
-    transform: translateY(4px);
-    box-shadow: 0px 12px 24px rgba(0, 0, 0, 0.08);
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: ${({ backgroundImage }) =>
+      backgroundImage ? "rgba(0, 0, 0, 0.5)" : "transparent"};
+    border-radius: 1rem;
+    pointer-events: none;
+    z-index: 0;
   }
 
-  &:focus-visible {
-    box-shadow: 0 0 0 3px rgba(0, 174, 255, 0.4);
+  > * {
+    position: relative;
+    z-index: 1;
   }
 `;
 
@@ -131,8 +122,10 @@ const CategoryTag = styled.div`
   justify-content: center;
   align-items: center;
   text-align: center;
+  font-style: normal;
+  font-weight: 600;
   border-radius: 0.5rem;
-  width: 4.5rem;
+  padding: 0.5rem;
   height: 1.4rem;
   font-size: 1rem;
   background-color: white;
@@ -140,17 +133,17 @@ const CategoryTag = styled.div`
 
 const CardTitle = styled.p`
   width: 100%;
-  font-size: 1.25rem; /* 20px */
+  font-size: 1.1875rem;
   font-style: normal;
   font-weight: 600;
-  line-height: 1.4;
-  margin-top: 0.75rem;
-  margin-bottom: 0.25rem;
+  line-height: 1.5rem;
+  margin-top: 0.69rem;
+  margin-left: 0.37rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   color: ${({ $hasBackgroundImage }) =>
-    $hasBackgroundImage ? "#fff" : "#000"};
+    $hasBackgroundImage ? "#ffffff" : "#000000"};
 `;
 
 const CardSubTitle = styled.p`
@@ -158,16 +151,18 @@ const CardSubTitle = styled.p`
   font-size: 0.9rem;
   font-weight: 400;
   margin-top: 0.1rem;
+  margin-left: 0.37rem;
   flex: 1;
   min-height: 0;
+  overflow-wrap: break-word;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
   word-break: break-word;
-  line-height: 1.4;
-  max-height: calc(1rem * 1.4 * 2);
+  line-height: 1.2;
+  max-height: 2.4em;
   color: ${({ $hasBackgroundImage }) =>
-    $hasBackgroundImage ? "#fff" : "#000"};
+    $hasBackgroundImage ? "#ffffff" : "#000000"};
 `;

--- a/src/pages/MakerPage/SidePanel/PromptHub/PromptCardList.jsx
+++ b/src/pages/MakerPage/SidePanel/PromptHub/PromptCardList.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import styled from "styled-components";
 import PromptCard from "./PromptCard";
 import moreButtonIcon from "../../assets/card-slider-more-button.svg";
@@ -6,6 +6,49 @@ import prevButtonIcon from "../../assets/card-slider-prev-button.svg";
 
 export default function PromptCardList({ prompts = [], onCardClick }) {
   const listWrapperRef = useRef(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const checkScrollability = () => {
+    if (!listWrapperRef.current) return;
+
+    const { scrollLeft, scrollWidth, clientWidth } = listWrapperRef.current;
+    const isAtStart = scrollLeft <= 5; // 5px tolerance
+    const isAtEnd = scrollLeft + clientWidth >= scrollWidth - 5; // 5px tolerance
+
+    setCanScrollLeft(!isAtStart);
+    setCanScrollRight(!isAtEnd);
+  };
+
+  useEffect(() => {
+    checkScrollability();
+
+    const element = listWrapperRef.current;
+    if (!element) return;
+
+    // 스크롤 이벤트에 디바운싱 적용
+    // 스크롤 이벤트 리스너 - 실시간 감지
+    let scrollTimeout;
+    const handleScroll = () => {
+      clearTimeout(scrollTimeout);
+      scrollTimeout = setTimeout(() => {
+        checkScrollability();
+      }, 50);
+    };
+
+    element.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", checkScrollability);
+
+    // 초기 체크를 위해 약간의 지연 후 다시 확인
+    const timeoutId = setTimeout(checkScrollability, 100);
+
+    return () => {
+      element.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", checkScrollability);
+      clearTimeout(timeoutId);
+      clearTimeout(scrollTimeout);
+    };
+  }, [prompts]);
 
   const handleScrollLeft = () => {
     if (listWrapperRef.current) {
@@ -15,6 +58,11 @@ export default function PromptCardList({ prompts = [], onCardClick }) {
         left: -scrollAmount,
         behavior: "smooth",
       });
+
+      // 스크롤 완료 후 상태 업데이트
+      setTimeout(() => {
+        checkScrollability();
+      }, 300);
     }
   };
 
@@ -26,6 +74,11 @@ export default function PromptCardList({ prompts = [], onCardClick }) {
         left: scrollAmount,
         behavior: "smooth",
       });
+
+      // 스크롤 완료 후 상태 업데이트
+      setTimeout(() => {
+        checkScrollability();
+      }, 300);
     }
   };
 
@@ -52,12 +105,16 @@ export default function PromptCardList({ prompts = [], onCardClick }) {
       </ListWrapper>
       {prompts.length > 0 && (
         <>
-          <PrevButton onClick={handleScrollLeft}>
-            <img src={prevButtonIcon} alt="이전" />
-          </PrevButton>
-          <NextButton onClick={handleScrollRight}>
-            <img src={moreButtonIcon} alt="다음" />
-          </NextButton>
+          {canScrollLeft && (
+            <PrevButton onClick={handleScrollLeft}>
+              <img src={prevButtonIcon} alt="이전" />
+            </PrevButton>
+          )}
+          {canScrollRight && (
+            <NextButton onClick={handleScrollRight}>
+              <img src={moreButtonIcon} alt="다음" />
+            </NextButton>
+          )}
         </>
       )}
     </ListContainer>
@@ -77,10 +134,17 @@ const ListWrapper = styled.div`
   display: flex;
   flex-direction: row;
   gap: 1rem;
-  overflow-x: hidden;
+  overflow-x: auto;
   overflow-y: hidden;
   padding-bottom: 0.2rem;
   scroll-behavior: smooth;
+
+  /* 스크롤바 숨기기 */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 `;
 
 const EmptyMessage = styled.div`

--- a/src/pages/MakerPage/SidePanel/TopPanel/HubModalSelector.jsx
+++ b/src/pages/MakerPage/SidePanel/TopPanel/HubModalSelector.jsx
@@ -7,7 +7,7 @@ export default function HubModalSelector() {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef(null);
 
-  const models = ["모든 허브", "아카이브", "좋아요"];
+  const models = ["모든 허브", "내가 작성한 글", "좋아요"];
 
   // 외부 클릭 감지
   useEffect(() => {
@@ -74,12 +74,12 @@ const SelectorWrapper = styled.div`
 `;
 
 const SelectorButton = styled.button`
-  width: 18.23vw;
-  height: 4.54vh;
+  width: 21.875rem;
+  height: 3.0625rem;
   background-color: #ffffff;
   border: 0.0625rem solid #aadff7;
   border-radius: 120px;
-  padding: 0 1vw 0 1.5vw;
+  padding: 0 1rem 0 1.5rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -98,14 +98,15 @@ const ModelInfo = styled.div`
 
 const ModelName = styled.span`
   font-family: "Pretendard Variable", sans-serif;
-  font-size: 0.99vw;
+  font-size: 1.1875rem;
+  line-height: 100%;
   font-weight: 500;
   color: #454545;
 `;
 
 const DropdownIcon = styled.img`
-  width: 1.35vw;
-  height: 2.41vh;
+  width: 1.25rem;
+  height: 1.25rem;
 `;
 
 const DropdownMenu = styled.div`
@@ -114,7 +115,7 @@ const DropdownMenu = styled.div`
   left: 0;
   background: white;
   border: 0.1rem solid #aadff7;
-  width: 18.23vw;
+  width: 21.875rem;
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   margin-top: 0.5rem;
@@ -130,7 +131,7 @@ const MenuItem = styled.button`
   text-align: left;
   cursor: pointer;
   font-family: "Pretendard Variable", sans-serif;
-  font-size: 0.99vw;
+  font-size: 1rem;
   color: ${(props) => (props.$isSelected ? "#001e40" : "#454545")};
 
   &:hover {

--- a/src/pages/MakerPage/SidePanel/TopPanel/SearchInput.jsx
+++ b/src/pages/MakerPage/SidePanel/TopPanel/SearchInput.jsx
@@ -41,15 +41,16 @@ export default function SearchInput({
 
 // 1. 전체를 감싸는 div (여기 에 모든 겉모양 스타일을 적용)
 const SearchContainer = styled.div`
-  width: ${(props) => props.$width ?? "18.23vw"}; /* 350px @ 1920px */
-  height: 4.54vh; /* 49px @ 1080px */
+  width: ${(props) => props.$width ?? "21.875rem"}; /* 350px @ 1920px */
+  height: 3.0625rem;
   background-color: #ffffff;
   border: 0.0625rem solid #aadff7;
   border-radius: 120px;
-  padding: 0.37vh 0.68vw; /* 4px 13px */
+  padding: 0.25rem 0.8125rem; /* 4px 13px */
   display: flex;
   align-items: center;
-  gap: 0.52vw; /* 10px */
+  gap: 0.625rem; /* 10px */
+  flex-shrink: 0;
 `;
 
 // 2. 텍스트 입력 input (테두리, 배경 등은 모두 제거)
@@ -60,7 +61,7 @@ const StyledInput = styled.input`
   outline: none;
   background-color: transparent;
   padding: 0;
-  font-size: 1vw; /* 23px @ 1920px */
+  font-size: 1.1875rem; /* 23px @ 1920px */
   font-family: "Pretendard Variable", sans-serif;
   font-weight: 500;
   color: #454545;
@@ -83,6 +84,6 @@ const SearchButton = styled.button`
 `;
 
 const SearchButtonIcon = styled.img`
-  width: 1.3vw; /* 36px @ 1920px */
+  width: 1.5rem; /* 36px @ 1920px */
   height: auto;
 `;

--- a/src/pages/MakerPage/SidePanel/TopPanel/TopPanel.jsx
+++ b/src/pages/MakerPage/SidePanel/TopPanel/TopPanel.jsx
@@ -12,17 +12,19 @@ export default function TopPanel({
 }) {
   return (
     <TopContainer>
-      <SearchInput
-        value={searchValue}
-        onChange={onSearchChange}
-        onSearch={onSearchSubmit}
-      />
+      <SearchRow>
+        <SearchInput
+          value={searchValue}
+          onChange={onSearchChange}
+          onSearch={onSearchSubmit}
+        />
+        {onClose && (
+          <CloseButton onClick={onClose} aria-label="사이드바 닫기">
+            <CloseIcon src={SidePanelCloseImg} />
+          </CloseButton>
+        )}
+      </SearchRow>
       <HubModalSelector />
-      {onClose && (
-        <CloseButton onClick={onClose} aria-label="사이드바 닫기">
-          <CloseIcon src={SidePanelCloseImg} />
-        </CloseButton>
-      )}
     </TopContainer>
   );
 }
@@ -37,13 +39,16 @@ const TopContainer = styled.div`
   padding: 2.7vh 1.93vw;
   width: 100%;
   background-color: #f6fcff;
-  position: relative;
+`;
+
+const SearchRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
 `;
 
 const CloseButton = styled.button`
-  position: absolute;
-  right: 1rem;
-  top: 1rem;
   width: 2rem;
   height: 2rem;
   background-color: transparent;
@@ -52,6 +57,7 @@ const CloseButton = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 
   &:hover {
     opacity: 0.7;
@@ -60,5 +66,5 @@ const CloseButton = styled.button`
 
 const CloseIcon = styled.img`
   width: auto;
-  height: 2.5vh;
+  height: 1.5rem;
 `;


### PR DESCRIPTION
## 📝 PR 유형

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [x] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #156 

## ✅ 작업 목록

- [x] SidePanel 전체적으로 UI 수정
- [x] (로직 변경) SidePanel에 있는 PromptCardList를 호버하면 이전/다음 버튼 뜨는 로직 변경
      - 기존 : 이전/다음에 프롬프트 카드가 없어도 두 버튼 모두 활성화됨, 스크롤 불가
      - 개선 : 이전/다음에 프롬프트 카드가 없으면 이를 감지하여 1개의 버튼을 띄우지 않음, 스크롤 가능
- [x] PromptEditor(메이커 입력 부분) 폰트 크기 수정

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<img width="1776" height="965" alt="image" src="https://github.com/user-attachments/assets/f236194b-b3f8-43d1-a08a-cedfed41eed9" />
