### PR TITLE
155 feat / 메이커 피드백 UI 및 API 연동

### DIFF
--- a/src/pages/MakerPage/MainPanel/MainPanel.jsx
+++ b/src/pages/MakerPage/MainPanel/MainPanel.jsx
@@ -11,6 +11,8 @@ export default function MainPanel({
   onToggleSidebar,
   promptContent,
   onPromptContentChange,
+  attachedImages,
+  onAttachedImagesChange,
   onUpgradeRequest,
   onAcceptUpgrade,
   onCancelUpgrade,
@@ -64,7 +66,10 @@ export default function MainPanel({
             />
           </PromptInputWrapper>
         </TopSection>
-        <ImageUploader />
+        <ImageUploader
+          attachedImages={attachedImages}
+          onAttachedImagesChange={onAttachedImagesChange}
+        />
       </ContentArea>
     </MakerPanelWrapper>
   );

--- a/src/pages/MakerPage/MakerPage.jsx
+++ b/src/pages/MakerPage/MakerPage.jsx
@@ -9,6 +9,12 @@ import {
   upgradeMakerText,
   reupgradeMakerText,
 } from "./api/makers";
+import {
+  runPrompt,
+  getRunHistory,
+  restoreHistory,
+  getPromptFeedback,
+} from "./api/results";
 
 export default function MakerPage({ selectedPrompt = null }) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(true);
@@ -21,14 +27,28 @@ export default function MakerPage({ selectedPrompt = null }) {
   );
   const [attachedImages, setAttachedImages] = useState([]);
   const [latestUpgradeId, setLatestUpgradeId] = useState(null);
-  const [currentHistoryIndex, setCurrentHistoryIndex] = useState(3);
-  const [resultImageUrl] = useState(null);
-  const [isResultLoading] = useState(false);
+  const [currentHistoryIndex, setCurrentHistoryIndex] = useState(1);
+  const [resultImageUrl, setResultImageUrl] = useState(
+    selectedPrompt?.resultImageUrl ?? null
+  );
+  const [resultText, setResultText] = useState(
+    selectedPrompt?.resultText ?? null
+  );
+
+  const [resultType, setResultType] = useState(
+    selectedPrompt?.resultType ?? null
+  );
+  const [resultFeedback, setResultFeedback] = useState(null);
+  const [historyFeedbackMap, setHistoryFeedbackMap] = useState({});
+  const [isResultLoading, setIsResultLoading] = useState(false);
+  const [historyItems, setHistoryItems] = useState([]);
+  const [currentHistoryId, setCurrentHistoryId] = useState(null);
   const [currentMakerId, setCurrentMakerId] = useState(
     selectedPrompt?.makerId ?? null
   );
   const [existingImageUrls, setExistingImageUrls] = useState([]);
   const saveIntervalRef = useRef(null);
+  const skipNextAutoSaveRef = useRef(false);
   const isSavingRef = useRef(false);
   const isInitialLoadRef = useRef(true); // 초기 로드 여부 추적
 
@@ -44,13 +64,59 @@ export default function MakerPage({ selectedPrompt = null }) {
     newImageCount: 0,
   });
 
-  // 히스토리 mock 데이터
-  const historyItems = [
-    { id: 1, title: "남자 캐릭터로 변경 요청", status: "New" },
-    { id: 2, title: "배경 변경 요청", time: "PM 16:42" },
-    { id: 3, title: "머리스타일 변경 요청", time: "PM 16:48" },
-    { id: 4, title: "제발", time: "PM 16:48" },
-  ];
+  // 히스토리 목록 조회 (목록/인덱스만 세팅, 내용은 자동 복원하지 않음)
+  useEffect(() => {
+    const fetchHistory = async () => {
+      if (!currentMakerId) return;
+
+      try {
+        const histories = await getRunHistory(currentMakerId);
+        const formattedHistories = histories.map((history) => ({
+          id: history.historyId,
+          title: history.title || `History ${history.historyId}`,
+        }));
+        setHistoryItems(formattedHistories);
+
+        // 가장 최신 히스토리의 인덱스/ID만 기억
+        if (formattedHistories.length > 0) {
+          const latest = formattedHistories[0];
+          setCurrentHistoryIndex(1);
+          setCurrentHistoryId(latest.id);
+        }
+      } catch (error) {
+        console.error("히스토리 조회 실패:", error);
+      }
+    };
+
+    fetchHistory();
+  }, [currentMakerId]);
+
+  // makerId 변경 시, 로컬스토리지에 저장된 피드백 캐시 불러오기
+  useEffect(() => {
+    if (!currentMakerId) return;
+
+    try {
+      const raw = localStorage.getItem(`makerFeedback:${currentMakerId}`);
+      if (!raw) return;
+
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        setHistoryFeedbackMap(parsed);
+      }
+    } catch (error) {
+      console.error("피드백 캐시 로드 실패:", error);
+    }
+  }, [currentMakerId]);
+
+  // 선택된 히스토리가 바뀔 때, 캐시에 피드백이 있으면 바로 반영
+  useEffect(() => {
+    if (!currentHistoryId) return;
+
+    const cachedFeedback = historyFeedbackMap[currentHistoryId];
+    if (cachedFeedback !== undefined) {
+      setResultFeedback(cachedFeedback);
+    }
+  }, [currentHistoryId, historyFeedbackMap]);
 
   useEffect(() => {
     const title = selectedPrompt?.title ?? "";
@@ -59,6 +125,11 @@ export default function MakerPage({ selectedPrompt = null }) {
     setPromptTitle(title);
     setPromptContent(content);
     setCurrentMakerId(selectedPrompt?.makerId ?? null);
+
+    // 선택된 메이커가 바뀔 때, 마지막 실행 결과도 함께 반영
+    setResultType(selectedPrompt?.resultType ?? null);
+    setResultImageUrl(selectedPrompt?.resultImageUrl ?? null);
+    setResultText(selectedPrompt?.resultText ?? null);
 
     // 기존 이미지 URL 추출 (서버에서 받은 이미지들)
     let urls = [];
@@ -118,6 +189,10 @@ export default function MakerPage({ selectedPrompt = null }) {
 
     // 저장 함수
     const performAutoSave = async () => {
+      if (skipNextAutoSaveRef.current) {
+        skipNextAutoSaveRef.current = false;
+        return;
+      }
       // 이미 저장 중이면 스킵
       if (isSavingRef.current) {
         return;
@@ -515,17 +590,178 @@ export default function MakerPage({ selectedPrompt = null }) {
       <ResultPanel
         isOpen={isResultPanelOpen}
         onToggle={() => setIsResultPanelOpen(false)}
-        onRun={() => {
-          // TODO: 프롬프트 실행 로직
-          console.log("프롬프트 실행:", promptContent);
+        onRun={async () => {
+          if (!currentMakerId || !promptContent.trim()) {
+            alert("메이커 ID 또는 프롬프트 내용이 없습니다.");
+            return;
+          }
+
+          setIsResultLoading(true);
+          try {
+            // RUN 전에 한 번 더 강제 자동 저장을 실행하여
+            // 히스토리 스냅샷과 MainPanel 내용이 최대한 일치하도록 맞춘다.
+            try {
+              // 전송해야 할 로컬 이미지 파일들
+              const newImages = attachedImages.filter(
+                (img) => img.file && !img.isServerImage
+              );
+
+              // 현재 attachedImages에 있는 서버 이미지 URL들만 추출
+              const serverImageUrls = attachedImages
+                .filter((img) => img.imageUrl || img.url || img.isServerImage)
+                .map((img) => img.imageUrl || img.url)
+                .filter(Boolean);
+
+              const urlsToKeep = serverImageUrls;
+
+              const newImageFiles = newImages
+                .map((img) => img.file)
+                .filter(Boolean);
+
+              await autoSaveMaker(currentMakerId, {
+                title: promptTitle,
+                content: promptContent,
+                existingImageUrls: urlsToKeep,
+                newImages: newImageFiles,
+              });
+            } catch (e) {
+              // 강제 자동 저장 실패는 RUN 자체를 막지는 않는다.
+              console.error("RUN 직전 자동 저장 실패:", e);
+            }
+
+            const result = await runPrompt(currentMakerId, promptContent);
+
+            // 결과 저장
+            setResultType(result.resultType);
+            setResultImageUrl(result.resultImageUrl || null);
+            setResultText(result.resultText || null);
+            setCurrentHistoryId(result.historyId);
+
+            // 히스토리 목록 새로고침
+            const histories = await getRunHistory(currentMakerId);
+            const formattedHistories = histories.map((history) => ({
+              id: history.historyId,
+              title: history.title || `History ${history.historyId}`,
+            }));
+            setHistoryItems(formattedHistories);
+
+            // 가장 최신 히스토리 선택 (인덱스 1)
+            setCurrentHistoryIndex(1);
+
+            // 최신 프롬프트에 대한 피드백 조회 (히스토리별로 한 번만 호출)
+            const cachedFeedback = historyFeedbackMap[result.historyId];
+            if (cachedFeedback !== undefined) {
+              setResultFeedback(cachedFeedback);
+            } else {
+              try {
+                const feedbackResponse = await getPromptFeedback(
+                  currentMakerId
+                );
+                const feedbackText = feedbackResponse?.feedback ?? null;
+
+                setResultFeedback(feedbackText);
+                setHistoryFeedbackMap((prev) => {
+                  const next = { ...prev, [result.historyId]: feedbackText };
+                  try {
+                    localStorage.setItem(
+                      `makerFeedback:${currentMakerId}`,
+                      JSON.stringify(next)
+                    );
+                  } catch (error) {
+                    console.error("피드백 캐시 저장 실패:", error);
+                  }
+                  return next;
+                });
+              } catch (e) {
+                console.error("피드백 조회 실패:", e);
+              }
+            }
+          } catch (error) {
+            console.error("프롬프트 실행 실패:", error);
+            alert("프롬프트 실행에 실패했습니다.");
+          } finally {
+            setIsResultLoading(false);
+          }
         }}
         currentHistoryIndex={currentHistoryIndex}
         historyItems={historyItems}
-        onHistoryItemClick={(item, index) => {
-          setCurrentHistoryIndex(index + 1);
-          console.log("히스토리 항목 클릭:", item, index);
+        feedbackText={resultFeedback}
+        onHistoryItemClick={async (item, index) => {
+          if (!currentMakerId || !item.id) {
+            console.error("메이커 ID 또는 히스토리 ID가 없습니다.");
+            return;
+          }
+
+          try {
+            const restored = await restoreHistory(currentMakerId, item.id);
+            skipNextAutoSaveRef.current = true;
+            // 메이커 내용 복원
+            setPromptTitle(restored.snapshotTitle || "");
+            setPromptContent(restored.snapshotContent || "");
+
+            // 이미지 복원
+            if (
+              restored.snapshotImages &&
+              Array.isArray(restored.snapshotImages)
+            ) {
+              const restoredImages = restored.snapshotImages.map((img) => ({
+                id: Date.now() + Math.random(),
+                imageUrl: img.imageUrl,
+                isServerImage: true,
+              }));
+              setAttachedImages(restoredImages);
+              setExistingImageUrls(
+                restored.snapshotImages
+                  .map((img) => img.imageUrl)
+                  .filter(Boolean)
+              );
+            } else {
+              setAttachedImages([]);
+              setExistingImageUrls([]);
+            }
+
+            // 결과 표시
+            setResultType(restored.resultType);
+            setResultImageUrl(restored.resultImageUrl || null);
+            setResultText(restored.resultText || null);
+            setCurrentHistoryId(restored.historyId);
+            setCurrentHistoryIndex(index + 1);
+
+            // 복원된 프롬프트에 대한 피드백: 캐시 우선, 없으면 한 번만 조회
+            const targetHistoryId = restored.historyId ?? item.id;
+            const cachedFeedback = historyFeedbackMap[targetHistoryId];
+            if (cachedFeedback !== undefined) {
+              setResultFeedback(cachedFeedback);
+            } else {
+              try {
+                const feedbackResponse = await getPromptFeedback(
+                  currentMakerId
+                );
+                const feedbackText = feedbackResponse?.feedback ?? null;
+                setResultFeedback(feedbackText);
+                setHistoryFeedbackMap((prev) => {
+                  const next = { ...prev, [targetHistoryId]: feedbackText };
+                  try {
+                    localStorage.setItem(
+                      `makerFeedback:${currentMakerId}`,
+                      JSON.stringify(next)
+                    );
+                  } catch (error) {
+                    console.error("피드백 캐시 저장 실패:", error);
+                  }
+                  return next;
+                });
+              } catch (e) {
+                console.error("피드백 조회 실패:", e);
+              }
+            }
+          } catch (error) {
+            console.error("히스토리 복원 실패:", error);
+            alert("히스토리 복원에 실패했습니다.");
+          }
         }}
         resultImageUrl={resultImageUrl}
+        resultText={resultText}
         isResultLoading={isResultLoading}
       />
 
@@ -538,11 +774,83 @@ export default function MakerPage({ selectedPrompt = null }) {
         }}
         currentHistoryIndex={currentHistoryIndex}
         historyItems={historyItems}
-        onHistoryItemClick={(item, index) => {
-          setCurrentHistoryIndex(index + 1);
-          console.log("히스토리 항목 클릭:", item, index);
+        onHistoryItemClick={async (item, index) => {
+          if (!currentMakerId || !item.id) {
+            console.error("메이커 ID 또는 히스토리 ID가 없습니다.");
+            return;
+          }
+
+          try {
+            const restored = await restoreHistory(currentMakerId, item.id);
+            skipNextAutoSaveRef.current = true;
+            // 메이커 내용 복원
+            setPromptTitle(restored.snapshotTitle || "");
+            setPromptContent(restored.snapshotContent || "");
+
+            // 이미지 복원
+            if (
+              restored.snapshotImages &&
+              Array.isArray(restored.snapshotImages)
+            ) {
+              const restoredImages = restored.snapshotImages.map((img) => ({
+                id: Date.now() + Math.random(),
+                imageUrl: img.imageUrl,
+                isServerImage: true,
+              }));
+              setAttachedImages(restoredImages);
+              setExistingImageUrls(
+                restored.snapshotImages
+                  .map((img) => img.imageUrl)
+                  .filter(Boolean)
+              );
+            } else {
+              setAttachedImages([]);
+              setExistingImageUrls([]);
+            }
+
+            // 결과 표시
+            setResultType(restored.resultType);
+            setResultImageUrl(restored.resultImageUrl || null);
+            setResultText(restored.resultText || null);
+            setCurrentHistoryId(restored.historyId);
+            setCurrentHistoryIndex(index + 1);
+
+            // 복원된 프롬프트에 대한 피드백: 캐시 우선, 없으면 한 번만 조회
+            const targetHistoryId = restored.historyId ?? item.id;
+            const cachedFeedback = historyFeedbackMap[targetHistoryId];
+            if (cachedFeedback !== undefined) {
+              setResultFeedback(cachedFeedback);
+            } else {
+              try {
+                const feedbackResponse = await getPromptFeedback(
+                  currentMakerId
+                );
+                const feedbackText = feedbackResponse?.feedback ?? null;
+                setResultFeedback(feedbackText);
+                setHistoryFeedbackMap((prev) => {
+                  const next = { ...prev, [targetHistoryId]: feedbackText };
+                  try {
+                    localStorage.setItem(
+                      `makerFeedback:${currentMakerId}`,
+                      JSON.stringify(next)
+                    );
+                  } catch (error) {
+                    console.error("피드백 캐시 저장 실패:", error);
+                  }
+                  return next;
+                });
+              } catch (e) {
+                console.error("피드백 조회 실패:", e);
+              }
+            }
+          } catch (error) {
+            console.error("히스토리 복원 실패:", error);
+            alert("히스토리 복원에 실패했습니다.");
+          }
         }}
         resultImageUrl={resultImageUrl}
+        resultText={resultText}
+        feedbackText={resultFeedback}
         isResultLoading={isResultLoading}
       />
     </MakerPageWrapper>

--- a/src/pages/MakerPage/ResultPanel/ResultPanel.jsx
+++ b/src/pages/MakerPage/ResultPanel/ResultPanel.jsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "styled-components";
 import AIModalSelector from "../MainPanel/AIModalSelector";
 import ResultPanelCloseImg from "../assets/prompt-run-close.svg";
 import ResultDisplay from "../shared/ResultDisplay";
 import HistoryBar from "../shared/HistoryBar";
+import ResultFeedback from "../shared/ResultFeedback";
 
 export default function ResultPanel({
   isOpen = true,
@@ -13,8 +14,12 @@ export default function ResultPanel({
   historyItems = [],
   onHistoryItemClick,
   resultImageUrl = null,
+  resultText = null,
   isResultLoading = false,
+  feedbackText = null,
 }) {
+  const [activeTab, setActiveTab] = useState("HISTORY"); // "HISTORY" | "FEEDBACK"
+
   return (
     <ResultPanelWrapper $isOpen={isOpen}>
       <ResultPanelHeader>
@@ -32,13 +37,44 @@ export default function ResultPanel({
         </SecondWrapper>
       </ResultPanelHeader>
       <ResultContent>
-        <ResultDisplay isLoading={isResultLoading} imageUrl={resultImageUrl} />
-        <HistoryBar
-          currentIndex={currentHistoryIndex}
-          totalCount={historyItems.length || 10}
-          historyItems={historyItems}
-          onItemClick={onHistoryItemClick}
+        <ResultDisplay
+          isLoading={isResultLoading}
+          imageUrl={resultImageUrl}
+          textContent={resultText}
         />
+
+        <BottomSection>
+          <TabHeader>
+            <TabButton
+              type="button"
+              data-active={activeTab === "HISTORY"}
+              onClick={() => setActiveTab("HISTORY")}
+            >
+              <TabTitle>History</TabTitle>
+              <TabCount>
+                ({currentHistoryIndex}/{historyItems.length || 0})
+              </TabCount>
+            </TabButton>
+            <TabButton
+              type="button"
+              data-active={activeTab === "FEEDBACK"}
+              onClick={() => setActiveTab("FEEDBACK")}
+            >
+              <TabTitle>Feedback</TabTitle>
+            </TabButton>
+          </TabHeader>
+
+          {activeTab === "HISTORY" ? (
+            <HistoryBar
+              currentIndex={currentHistoryIndex}
+              totalCount={historyItems.length || 10}
+              historyItems={historyItems}
+              onItemClick={onHistoryItemClick}
+            />
+          ) : (
+            <ResultFeedback feedbackText={feedbackText} />
+          )}
+        </BottomSection>
       </ResultContent>
     </ResultPanelWrapper>
   );
@@ -71,6 +107,48 @@ const ResultContent = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
+`;
+
+const BottomSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const TabHeader = styled.div`
+  display: flex;
+  align-items: flex-end;
+  gap: 2rem;
+`;
+
+const TabButton = styled.button`
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.625rem;
+  border-bottom: 0.1875rem solid
+    ${(props) => (props["data-active"] ? "#21C3FF" : "transparent")};
+  color: ${(props) => (props["data-active"] ? "#000000" : "#A6A6A6")};
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;
+
+const TabTitle = styled.span`
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 1.4375rem;
+  font-weight: 700;
+`;
+
+const TabCount = styled.span`
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #848484;
 `;
 
 const SecondWrapper = styled.div`

--- a/src/pages/MakerPage/api/results.js
+++ b/src/pages/MakerPage/api/results.js
@@ -18,12 +18,11 @@ export const runPrompt = async (makerId, prompt) => {
   const params = new URLSearchParams();
   params.append("prompt", prompt);
 
-  // GPT API 호출은 시간이 오래 걸릴 수 있으므로 타임아웃을 120초(2분)로 설정
   const response = await apiClient.post(
     `/api/makers/${makerId}/histories/run?${params.toString()}`,
     null,
     {
-      timeout: 2000000, // 120초 (2분)
+      timeout: 2000000,
     }
   );
   return response.data;

--- a/src/pages/MakerPage/api/results.js
+++ b/src/pages/MakerPage/api/results.js
@@ -1,0 +1,81 @@
+// Result 관련 API 함수들 (프롬프트 실행 및 히스토리)
+import apiClient from "../../../api/client";
+
+/**
+ * 프롬프트를 GPT로 실행하고 History를 생성합니다.
+ * @param {number} makerId - 메이커 ID (필수)
+ * @param {string} prompt - 실행할 프롬프트 내용 (필수)
+ * @returns {Promise<{historyId: number, resultType: string, resultText: string, resultImageUrl: string, createdAt: string}>} 실행 결과 및 히스토리 정보
+ */
+export const runPrompt = async (makerId, prompt) => {
+  if (!makerId) {
+    throw new Error("makerId는 필수입니다.");
+  }
+  if (!prompt) {
+    throw new Error("prompt는 필수입니다.");
+  }
+
+  const params = new URLSearchParams();
+  params.append("prompt", prompt);
+
+  // GPT API 호출은 시간이 오래 걸릴 수 있으므로 타임아웃을 120초(2분)로 설정
+  const response = await apiClient.post(
+    `/api/makers/${makerId}/histories/run?${params.toString()}`,
+    null,
+    {
+      timeout: 2000000, // 120초 (2분)
+    }
+  );
+  return response.data;
+};
+
+/**
+ * 메이커의 히스토리 목록을 조회합니다 (최신순).
+ * @param {number} makerId - 메이커 ID (필수)
+ * @returns {Promise<Array<{historyId: number, title: string}>>} 히스토리 목록
+ */
+export const getRunHistory = async (makerId) => {
+  if (!makerId) {
+    throw new Error("makerId는 필수입니다.");
+  }
+
+  const response = await apiClient.get(`/api/makers/${makerId}/histories`);
+  return response.data;
+};
+
+/**
+ * 선택한 히스토리로 메이커를 복원합니다.
+ * @param {number} makerId - 메이커 ID (필수)
+ * @param {number} historyId - 히스토리 ID (필수)
+ * @returns {Promise<{historyId: number, snapshotTitle: string, snapshotContent: string, snapshotImages: Array<{imageUrl: string, orderIndex: number}>, resultType: string, resultText: string, resultImageUrl: string, createdAt: string}>} 복원된 메이커 정보 및 결과
+ */
+export const restoreHistory = async (makerId, historyId) => {
+  if (!makerId) {
+    throw new Error("makerId는 필수입니다.");
+  }
+  if (!historyId) {
+    throw new Error("historyId는 필수입니다.");
+  }
+
+  const response = await apiClient.patch(
+    `/api/makers/${makerId}/histories/${historyId}/restore`
+  );
+  return response.data;
+};
+
+/**
+ * 현재 프롬프트에 대한 피드백을 조회합니다.
+ * @param {number} makerId - 메이커 ID (필수)
+ * @returns {Promise<{feedback: string}>} 피드백 문구
+ */
+export const getPromptFeedback = async (makerId) => {
+  if (!makerId) {
+    throw new Error("makerId는 필수입니다.");
+  }
+
+  const response = await apiClient.post(
+    `/api/makers/${makerId}/feedback`,
+    null
+  );
+  return response.data;
+};

--- a/src/pages/MakerPage/shared/HistoryBar.jsx
+++ b/src/pages/MakerPage/shared/HistoryBar.jsx
@@ -5,7 +5,6 @@ import historyDownButton from "../assets/historybar-down-button.svg";
 
 export default function HistoryBar({
   currentIndex = 1,
-  totalCount = 10,
   historyItems = [],
   onItemClick,
 }) {
@@ -62,13 +61,6 @@ export default function HistoryBar({
 
   return (
     <HistoryContainer>
-      <HistoryHeader>
-        <HistoryTitle>History</HistoryTitle>
-        <HistoryCount>
-          ({currentIndex}/{totalCount})
-        </HistoryCount>
-      </HistoryHeader>
-
       {historyItems.length > 0 ? (
         <HistoryListWrapper>
           <ScrollableArea

--- a/src/pages/MakerPage/shared/ResultDisplay.jsx
+++ b/src/pages/MakerPage/shared/ResultDisplay.jsx
@@ -18,10 +18,8 @@ export default function ResultDisplay({ imageUrl, textContent, isLoading }) {
 
 const DisplayContainer = styled.div`
   position: relative;
-  width: 27.3125rem; /* 437px - Figma 디자인 기준 */
-  height: 26.3125rem; /* 421px - Figma 디자인 기준 */
-  border-radius: 0.925rem;
-  background-color: #f2f2f2;
+  width: 29.25rem;
+  height: 25.6875rem;
   overflow: hidden;
   display: flex;
   align-items: center;
@@ -46,13 +44,12 @@ const ResultImage = styled.img`
 const TextContent = styled.div`
   width: 100%;
   height: 100%;
-  padding: 1.5rem;
   overflow-y: auto;
   font-family: "Pretendard Variable", sans-serif;
-  font-size: 1.0625rem; /* 17px */
-  line-height: 1.35;
+  font-size: 1.25rem;
+  line-height: 1.625rem;
+  letter-spacing: 0;
   color: #000000;
-  letter-spacing: -0.425px;
   box-sizing: border-box;
 
   /* 스크롤바 숨기기 */

--- a/src/pages/MakerPage/shared/ResultFeedback.jsx
+++ b/src/pages/MakerPage/shared/ResultFeedback.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import styled from "styled-components";
+
+export default function ResultFeedback({ feedbackText }) {
+  const text =
+    (feedbackText && feedbackText.trim()) ||
+    "이 결과에 대한 피드백이 여기에 표시됩니다.";
+
+  return (
+    <FeedbackContainer>
+      <FeedbackText>{text}</FeedbackText>
+    </FeedbackContainer>
+  );
+}
+
+const FeedbackContainer = styled.section`
+  width: 100%;
+  border-radius: 0.5rem;
+  background-color: #e0f5ff;
+  padding: 1rem;
+  box-sizing: border-box;
+`;
+
+const FeedbackText = styled.p`
+  margin: 0;
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 1.1875rem;
+  line-height: 1.625rem;
+  letter-spacing: -2.5%;
+  color: #000000;
+  font-weight: 500;
+  white-space: pre-wrap;
+`;

--- a/src/pages/MakerPage/shared/ResultModal.jsx
+++ b/src/pages/MakerPage/shared/ResultModal.jsx
@@ -4,6 +4,7 @@ import ExpandIconImg from "../assets/result-modal-expansion-button.svg";
 import CloseIconImg from "../assets/result-modal-close-button.svg";
 import ResultDisplay from "./ResultDisplay";
 import HistoryBar from "./HistoryBar";
+import ResultFeedback from "./ResultFeedback";
 
 export default function ResultModal({
   isOpen,
@@ -13,8 +14,10 @@ export default function ResultModal({
   historyItems = [],
   onHistoryItemClick,
   resultImageUrl = null,
+  resultText = null,
   isResultLoading = false,
 }) {
+  const [activeTab, setActiveTab] = useState("HISTORY"); // "HISTORY" | "FEEDBACK"
   // 모달 크기는 CSS에서 관리하고, JavaScript에서는 실제 렌더링된 크기를 사용
   const modalRef = useRef(null);
 
@@ -38,6 +41,11 @@ export default function ResultModal({
         const currentWidth = rect.width;
         const currentHeight = rect.height;
 
+        // 크기가 0이면 아직 렌더링이 완료되지 않은 것
+        if (currentWidth === 0 || currentHeight === 0) {
+          return;
+        }
+
         // 오른쪽 여백
         const rightMarginPx = 32;
 
@@ -56,10 +64,22 @@ export default function ResultModal({
         setIsPositionCalculated(true);
       };
 
-      // DOM이 완전히 렌더링된 후 실제 크기로 위치 계산
+      // DOM이 완전히 렌더링되고 레이아웃이 안정화된 후 위치 계산
       // requestAnimationFrame을 두 번 사용하여 브라우저가 레이아웃을 완료한 후 실행
       requestAnimationFrame(() => {
-        requestAnimationFrame(updateSizeAndPosition);
+        requestAnimationFrame(() => {
+          // 한 번 더 확인하여 모달이 완전히 렌더링되었는지 확인
+          if (modalRef.current) {
+            updateSizeAndPosition();
+          } else {
+            // 아직 마운트되지 않았다면 약간의 지연 후 재시도
+            setTimeout(() => {
+              if (modalRef.current) {
+                updateSizeAndPosition();
+              }
+            }, 10);
+          }
+        });
       });
 
       // 화면 크기 변경 시에도 위치 재계산
@@ -106,13 +126,41 @@ export default function ResultModal({
           <ResultDisplay
             isLoading={isResultLoading}
             imageUrl={resultImageUrl}
+            textContent={resultText}
           />
-          <HistoryBar
-            currentIndex={currentHistoryIndex}
-            totalCount={historyItems.length || 10}
-            historyItems={historyItems}
-            onItemClick={onHistoryItemClick}
-          />
+
+          <BottomSection>
+            <TabHeader>
+              <TabButton
+                type="button"
+                data-active={activeTab === "HISTORY"}
+                onClick={() => setActiveTab("HISTORY")}
+              >
+                <TabTitle>History</TabTitle>
+                <TabCount>
+                  ({currentHistoryIndex}/{historyItems.length || 0})
+                </TabCount>
+              </TabButton>
+              <TabButton
+                type="button"
+                data-active={activeTab === "FEEDBACK"}
+                onClick={() => setActiveTab("FEEDBACK")}
+              >
+                <TabTitle>Feedback</TabTitle>
+              </TabButton>
+            </TabHeader>
+
+            {activeTab === "HISTORY" ? (
+              <HistoryBar
+                currentIndex={currentHistoryIndex}
+                totalCount={historyItems.length || 10}
+                historyItems={historyItems}
+                onItemClick={onHistoryItemClick}
+              />
+            ) : (
+              <ResultFeedback />
+            )}
+          </BottomSection>
         </ModalBody>
       </ModalContent>
     </ModalOverlay>
@@ -199,4 +247,46 @@ const ModalBody = styled.div`
   flex-direction: column;
   gap: 2rem;
   overflow-y: auto;
+`;
+
+const BottomSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+`;
+
+const TabHeader = styled.div`
+  display: flex;
+  align-items: flex-end;
+  gap: 2rem;
+`;
+
+const TabButton = styled.button`
+  border: none;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.625rem;
+  border-bottom: 0.1875rem solid
+    ${(props) => (props["data-active"] ? "#21C3FF" : "transparent")};
+  color: ${(props) => (props["data-active"] ? "#000000" : "#A6A6A6")};
+
+  &:hover {
+    opacity: 0.9;
+  }
+`;
+
+const TabTitle = styled.span`
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 1.4375rem;
+  font-weight: 700;
+`;
+
+const TabCount = styled.span`
+  font-family: "Pretendard Variable", sans-serif;
+  font-size: 1rem;
+  font-weight: 500;
+  color: #848484;
 `;


### PR DESCRIPTION
## 📝 PR 유형

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [x] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #155

## ✅ 작업 목록

- [x] ResultFeedBack 컴포넌트 추가
- [x] ResultModal 및 ResultPanel에 히스토리/피드백을 버튼 형식으로 UI 변경
- [x] MakerPage 내 RUN 하기 직전에 자동저장 한 번 더 하도록 로직 수정
- [x] 메이커 모든 API 연동 완료 (이제 프론트 관련 로직만 수정)

## 🍰 논의사항

### 문제 1
- 마지막으로 사용자가 자동저장한 프롬프트 메이커를 나갔다가 들어왔을 때 처음 보이게 설정 중 
=> 히스토리는 가장 최근 결과를 가리키고 있어, 자동저장한 프롬프트와 최근 히스토리 사이 내용이 혼동될 수 있음
[개선 방향]
- 프롬프트 메이커는 사용자가 가장 마지막에 자동저장한 걸 보여주는 게 맞는 거 같고, 히스토리는 그냥 아예 선택하지 않고, 눌러야만 보이는 걸로 로직 변경 

### 문제 2
- 메이커 초기화면(홈)에서 이미지 들어갔을 때 삭제 버튼 UI 깨짐

### 문제 3
- 드래그 세부 오류 수정

### 논의 사항
피드백이 1분에 1번씩 가능한데, RUN을 아예 막아놓을지, 피드백 자체에 버튼을 두게 할 지 (기획팀이랑 논의 필요)

## 해야할 것
- [ ] 위의 오류 수정
- [ ] 결과 확장 패널 디자인 및 복사/저장 로직 구현
- [ ] ResultPanel이 History 유무에 따라 활성화/비활성화되는 로직 구현
