### PR TITLE
163 feat/ 결과 패널 History 여부에 따른 버튼/모달 여는 로직 구현

### DIFF
--- a/src/pages/MakerPage/MainPanel/MainPanel.jsx
+++ b/src/pages/MakerPage/MainPanel/MainPanel.jsx
@@ -19,6 +19,7 @@ export default function MainPanel({
   onEditUpgrade,
   activeUpgradeId,
   activeUpgrade,
+  historyItems = [],
   onRunPrompt,
   onOpenResultPanel,
   isResultPanelOpen = false,
@@ -48,6 +49,7 @@ export default function MainPanel({
               <ControlBar
                 onRun={onRunPrompt}
                 onOpenResultPanel={onOpenResultPanel}
+                hasHistory={historyItems.length > 0}
               />
             )}
           </TitleAndControlRow>

--- a/src/pages/MakerPage/MainPanel/ResultSection/ControlBar.jsx
+++ b/src/pages/MakerPage/MainPanel/ResultSection/ControlBar.jsx
@@ -1,9 +1,21 @@
 import React from "react";
 import styled from "styled-components";
 import AIModalSelector from "../AIModalSelector";
-import ResultPanelOpenImg from "../../assets/prompt-run-open-disabled.svg";
+import ResultPanelOpenEnabledImg from "../../assets/prompt-run-open-enabled.svg";
+import ResultPanelOpenDisabledImg from "../../assets/prompt-run-open-disabled.svg";
 
-export default function ControlBar({ onRun, onOpenResultPanel }) {
+export default function ControlBar({
+  onRun,
+  onOpenResultPanel,
+  hasHistory = false,
+}) {
+  const handleOpenResultPanel = () => {
+    // History가 있을 때만 ResultPanel 열기
+    if (hasHistory && onOpenResultPanel) {
+      onOpenResultPanel();
+    }
+  };
+
   return (
     <ControlBarWrapper>
       <AIModalSelector />
@@ -13,9 +25,12 @@ export default function ControlBar({ onRun, onOpenResultPanel }) {
           <ButtonText>RUN</ButtonText>
         </RunButton>
         <OpenResultPanelButton
-          src={ResultPanelOpenImg}
-          onClick={onOpenResultPanel}
+          src={
+            hasHistory ? ResultPanelOpenEnabledImg : ResultPanelOpenDisabledImg
+          }
+          onClick={handleOpenResultPanel}
           alt="결과 패널 열기"
+          $isEnabled={hasHistory}
         />
       </SecondWrapper>
     </ControlBarWrapper>
@@ -31,14 +46,15 @@ const SecondWrapper = styled.div`
 const OpenResultPanelButton = styled.img`
   width: 2.25rem;
   height: auto;
-  cursor: pointer;
+  cursor: ${(props) => (props.$isEnabled ? "pointer" : "not-allowed")};
+  opacity: ${(props) => (props.$isEnabled ? 1 : 0.5)};
 
   &:hover {
-    opacity: 0.8;
+    opacity: ${(props) => (props.$isEnabled ? 0.8 : 0.5)};
   }
 
   &:active {
-    transform: scale(0.95);
+    transform: ${(props) => (props.$isEnabled ? "scale(0.95)" : "none")};
   }
 `;
 

--- a/src/pages/MakerPage/MakerPage.jsx
+++ b/src/pages/MakerPage/MakerPage.jsx
@@ -580,11 +580,109 @@ export default function MakerPage({ selectedPrompt = null }) {
         onEditUpgrade={handleEditUpgrade}
         activeUpgradeId={latestUpgradeId}
         activeUpgrade={upgrades.find((u) => u.id === latestUpgradeId)}
-        onRunPrompt={() => {
-          // TODO: 프롬프트 실행 로직
-          setIsResultModalOpen(true);
+        historyItems={historyItems}
+        onRunPrompt={async () => {
+          // 확장되지 않은 상태에서 PROMPT RUN을 누르면 ResultModal 표시
+          if (!isResultPanelExpanded) {
+            // RUN 실행
+            if (!currentMakerId || !promptContent.trim()) {
+              alert("메이커 ID 또는 프롬프트 내용이 없습니다.");
+              return;
+            }
+
+            setIsResultLoading(true);
+            try {
+              // RUN 전에 한 번 더 강제 자동 저장을 실행
+              try {
+                const newImages = attachedImages.filter(
+                  (img) => img.file && !img.isServerImage
+                );
+
+                const serverImageUrls = attachedImages
+                  .filter((img) => img.imageUrl || img.url || img.isServerImage)
+                  .map((img) => img.imageUrl || img.url)
+                  .filter(Boolean);
+
+                const urlsToKeep = serverImageUrls;
+
+                const newImageFiles = newImages
+                  .map((img) => img.file)
+                  .filter(Boolean);
+
+                await autoSaveMaker(currentMakerId, {
+                  title: promptTitle,
+                  content: promptContent,
+                  existingImageUrls: urlsToKeep,
+                  newImages: newImageFiles,
+                });
+              } catch (e) {
+                console.error("RUN 직전 자동 저장 실패:", e);
+              }
+
+              const result = await runPrompt(currentMakerId, promptContent);
+
+              // 결과 저장
+              setResultType(result.resultType);
+              setResultImageUrl(result.resultImageUrl || null);
+              setResultText(result.resultText || null);
+              setCurrentHistoryId(result.historyId);
+
+              // 히스토리 목록 새로고침
+              const histories = await getRunHistory(currentMakerId);
+              const formattedHistories = histories.map((history) => ({
+                id: history.historyId,
+                title: history.title || `History ${history.historyId}`,
+              }));
+              setHistoryItems(formattedHistories);
+
+              // 가장 최신 히스토리 선택 (인덱스 1)
+              setCurrentHistoryIndex(1);
+
+              // 최신 프롬프트에 대한 피드백 조회
+              const cachedFeedback = historyFeedbackMap[result.historyId];
+              if (cachedFeedback !== undefined) {
+                setResultFeedback(cachedFeedback);
+              } else {
+                try {
+                  const feedbackResponse = await getPromptFeedback(
+                    currentMakerId
+                  );
+                  const feedbackText = feedbackResponse?.feedback ?? null;
+
+                  setResultFeedback(feedbackText);
+                  setHistoryFeedbackMap((prev) => {
+                    const next = { ...prev, [result.historyId]: feedbackText };
+                    try {
+                      localStorage.setItem(
+                        `makerFeedback:${currentMakerId}`,
+                        JSON.stringify(next)
+                      );
+                    } catch (error) {
+                      console.error("피드백 캐시 저장 실패:", error);
+                    }
+                    return next;
+                  });
+                } catch (e) {
+                  console.error("피드백 조회 실패:", e);
+                }
+              }
+
+              // ResultModal 표시
+              setIsResultModalOpen(true);
+            } catch (error) {
+              console.error("프롬프트 실행 실패:", error);
+              alert("프롬프트 실행에 실패했습니다.");
+            } finally {
+              setIsResultLoading(false);
+            }
+          }
         }}
-        onOpenResultPanel={() => setIsResultPanelOpen(true)}
+        onOpenResultPanel={() => {
+          // History가 있을 때만 ResultPanel 열기
+          if (historyItems.length > 0) {
+            setIsResultPanelOpen(true);
+          }
+        }}
         isResultPanelOpen={isResultPanelOpen}
         isResultPanelExpanded={isResultPanelExpanded}
       />


### PR DESCRIPTION
## 📝 PR 유형

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #163

## ✅ 작업 목록

- [x] ControlBar.jsx에 hasHistory props를 추가해 히스토리가 있을 때는 ResultPanel이 열리도록 설정 및 조건에 따른 버튼 이미지 구분
- [x] MainPanel에 해당 props 전달 및 또 다른 props 추가(hasHistory가 historyItems가 0보다 클 때)
- [x] MakerPage 내 확장되지 않은 상태에서 PROMT RUN을 누르면 이전 RUN과 똑같은 로직 추가
      - 추후 로직 구분 필요
      - 기존) 확장되지 않은 상태에서 PROMPT RUN을 누르면 아무 로직도 없이 단순히 ResultModal만 표시

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
