### PR TITLE
167 feat makerpage hub dropdown

### DIFF
--- a/src/pages/MakerPage/SidePanel/PromptHub/PromptHub.jsx
+++ b/src/pages/MakerPage/SidePanel/PromptHub/PromptHub.jsx
@@ -11,9 +11,15 @@ import {
   searchPrompts,
   getPromptDetail,
   getGeneratedPrompts,
+  getMyPrompts,
+  getLikedPrompts,
 } from "../../api";
 
-export default function PromptHub({ searchKeyword = "", onClearSearch }) {
+export default function PromptHub({
+  searchKeyword = "",
+  onClearSearch,
+  selectedHub = "모든 허브",
+}) {
   const [currentView, setCurrentView] = useState("main"); // "main" | "detail"
   const [selectedSection, setSelectedSection] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -39,12 +45,136 @@ export default function PromptHub({ searchKeyword = "", onClearSearch }) {
   const [generatedPrompts, setGeneratedPrompts] = useState([]);
   const [searchResults, setSearchResults] = useState([]);
 
+  // 내가 작성한 글 상태
+  const [myPrompts, setMyPrompts] = useState([]);
+  const [isMyPromptsLoading, setIsMyPromptsLoading] = useState(false);
+  const [myPromptsError, setMyPromptsError] = useState(null);
+
+  // 좋아요한 프롬프트 상태
+  const [likedPrompts, setLikedPrompts] = useState([]);
+  const [isLikedPromptsLoading, setIsLikedPromptsLoading] = useState(false);
+  const [likedPromptsError, setLikedPromptsError] = useState(null);
+
   useEffect(() => {
     if (searchKeyword) {
       setCurrentView("main");
       setSelectedSection(null);
     }
   }, [searchKeyword]);
+
+  // 내가 작성한 글 조회
+  useEffect(() => {
+    if (selectedHub !== "내가 작성한 글") {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const fetchMyPrompts = async () => {
+      setIsMyPromptsLoading(true);
+      setMyPromptsError(null);
+
+      try {
+        const params = {
+          category: "전체",
+        };
+        const data = await getMyPrompts(params);
+
+        console.log("내가 작성한 글 응답 데이터:", data);
+
+        const formattedPrompts = Array.isArray(data) ? data : [];
+
+        setMyPrompts(formattedPrompts);
+      } catch (fetchError) {
+        if (fetchError?.code === "ERR_CANCELED") {
+          return;
+        }
+
+        console.error("내가 작성한 글을 불러오지 못했습니다.", fetchError);
+
+        let errorMessage = "내가 작성한 글을 불러오지 못했습니다.";
+        if (
+          fetchError?.code === "ERR_NAME_NOT_RESOLVED" ||
+          fetchError?.message?.includes("ERR_NAME_NOT_RESOLVED")
+        ) {
+          errorMessage =
+            "서버에 연결할 수 없습니다. 서버가 준비되었는지 확인해주세요.";
+        } else if (fetchError?.response) {
+          errorMessage = `서버 오류: ${fetchError.response.status}`;
+        } else if (fetchError?.request) {
+          errorMessage = "서버로부터 응답을 받지 못했습니다.";
+        }
+
+        setMyPromptsError(errorMessage);
+        setMyPrompts([]);
+      } finally {
+        setIsMyPromptsLoading(false);
+      }
+    };
+
+    fetchMyPrompts();
+
+    return () => {
+      controller.abort();
+    };
+  }, [selectedHub]);
+
+  // 좋아요한 프롬프트 조회
+  useEffect(() => {
+    if (selectedHub !== "좋아요") {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const fetchLikedPrompts = async () => {
+      setIsLikedPromptsLoading(true);
+      setLikedPromptsError(null);
+
+      try {
+        const params = {
+          category: "전체",
+        };
+        const data = await getLikedPrompts(params);
+
+        console.log("좋아요한 프롬프트 응답 데이터:", data);
+
+        const formattedPrompts = Array.isArray(data) ? data : [];
+
+        setLikedPrompts(formattedPrompts);
+      } catch (fetchError) {
+        if (fetchError?.code === "ERR_CANCELED") {
+          return;
+        }
+
+        console.error("좋아요한 프롬프트를 불러오지 못했습니다.", fetchError);
+
+        let errorMessage = "좋아요한 프롬프트를 불러오지 못했습니다.";
+        if (
+          fetchError?.code === "ERR_NAME_NOT_RESOLVED" ||
+          fetchError?.message?.includes("ERR_NAME_NOT_RESOLVED")
+        ) {
+          errorMessage =
+            "서버에 연결할 수 없습니다. 서버가 준비되었는지 확인해주세요.";
+        } else if (fetchError?.response) {
+          errorMessage = `서버 오류: ${fetchError.response.status}`;
+        } else if (fetchError?.request) {
+          errorMessage = "서버로부터 응답을 받지 못했습니다.";
+        }
+
+        setLikedPromptsError(errorMessage);
+        setLikedPrompts([]);
+      } finally {
+        setIsLikedPromptsLoading(false);
+      }
+    };
+
+    fetchLikedPrompts();
+
+    return () => {
+      controller.abort();
+    };
+  }, [selectedHub]);
 
   // 최근 조회한 프롬프트 조회
   useEffect(() => {
@@ -363,6 +493,46 @@ export default function PromptHub({ searchKeyword = "", onClearSearch }) {
           prompts={selectedSection.prompts}
           onCardClick={handleCardClick}
           onBack={handleBack}
+        />
+        <PromptDetailModal
+          isOpen={isModalOpen}
+          onClose={handleCloseModal}
+          promptId={selectedPromptId}
+        />
+      </>
+    );
+  }
+
+  // "내가 작성한 글" 선택 시
+  if (selectedHub === "내가 작성한 글") {
+    return (
+      <>
+        <PromptSectionDetail
+          sectionTitle="내가 작성한 글"
+          prompts={myPrompts}
+          onCardClick={handleCardClick}
+          isLoading={isMyPromptsLoading}
+          error={myPromptsError}
+        />
+        <PromptDetailModal
+          isOpen={isModalOpen}
+          onClose={handleCloseModal}
+          promptId={selectedPromptId}
+        />
+      </>
+    );
+  }
+
+  // "좋아요" 선택 시
+  if (selectedHub === "좋아요") {
+    return (
+      <>
+        <PromptSectionDetail
+          sectionTitle="좋아요"
+          prompts={likedPrompts}
+          onCardClick={handleCardClick}
+          isLoading={isLikedPromptsLoading}
+          error={likedPromptsError}
         />
         <PromptDetailModal
           isOpen={isModalOpen}

--- a/src/pages/MakerPage/SidePanel/PromptHub/PromptSectionDetail.jsx
+++ b/src/pages/MakerPage/SidePanel/PromptHub/PromptSectionDetail.jsx
@@ -8,18 +8,26 @@ export default function PromptSectionDetail({
   prompts = [],
   onCardClick,
   onBack,
+  isLoading = false,
+  error = null,
 }) {
   return (
     <Wrapper>
       <Header>
-        <BackButton onClick={onBack}>
-          <img src={backButtonIcon} alt="뒤로" />
-        </BackButton>
+        {onBack && (
+          <BackButton onClick={onBack}>
+            <img src={backButtonIcon} alt="뒤로" />
+          </BackButton>
+        )}
         <Title>{sectionTitle}</Title>
       </Header>
       <ContentArea>
         <CardList>
-          {prompts.length > 0 ? (
+          {isLoading ? (
+            <EmptyMessage>프롬프트를 불러오는 중입니다...</EmptyMessage>
+          ) : error ? (
+            <EmptyMessage>{error}</EmptyMessage>
+          ) : prompts.length > 0 ? (
             prompts.map((prompt) => (
               <PromptCard
                 key={prompt.promptId ?? prompt.id}

--- a/src/pages/MakerPage/SidePanel/SidePanel.jsx
+++ b/src/pages/MakerPage/SidePanel/SidePanel.jsx
@@ -17,6 +17,7 @@ export default function SidePanel({
   const hasUpgrades = Array.isArray(upgrades) && upgrades.length > 0;
   const [searchInput, setSearchInput] = useState("");
   const [searchKeyword, setSearchKeyword] = useState("");
+  const [selectedHub, setSelectedHub] = useState("모든 허브");
 
   useEffect(() => {
     if (searchInput.trim() === "") {
@@ -45,6 +46,8 @@ export default function SidePanel({
         searchValue={searchInput}
         onSearchChange={handleSearchChange}
         onSearchSubmit={handleSearchSubmit}
+        selectedHub={selectedHub}
+        onHubChange={setSelectedHub}
       />
       <ContentWrapper>
         {hasUpgrades ? (
@@ -62,6 +65,7 @@ export default function SidePanel({
             <PromptHub
               searchKeyword={searchKeyword}
               onClearSearch={handleClearSearch}
+              selectedHub={selectedHub}
             />
           </PromptHubContainer>
         )}

--- a/src/pages/MakerPage/SidePanel/TopPanel/HubModalSelector.jsx
+++ b/src/pages/MakerPage/SidePanel/TopPanel/HubModalSelector.jsx
@@ -2,8 +2,7 @@ import React, { useState, useRef, useEffect } from "react";
 import styled from "styled-components";
 import HubDropdownImg from "../../assets/hub-modal-dropdown.svg";
 
-export default function HubModalSelector() {
-  const [selectedModel, setSelectedModel] = useState("모든 허브");
+export default function HubModalSelector({ selectedModel, onModelChange }) {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef(null);
 
@@ -50,7 +49,7 @@ export default function HubModalSelector() {
             <MenuItem
               key={model}
               onClick={() => {
-                setSelectedModel(model);
+                onModelChange?.(model);
                 setIsOpen(false);
               }}
               $isSelected={model === selectedModel}

--- a/src/pages/MakerPage/SidePanel/TopPanel/TopPanel.jsx
+++ b/src/pages/MakerPage/SidePanel/TopPanel/TopPanel.jsx
@@ -9,6 +9,8 @@ export default function TopPanel({
   searchValue = "",
   onSearchChange,
   onSearchSubmit,
+  selectedHub = "모든 허브",
+  onHubChange,
 }) {
   return (
     <TopContainer>
@@ -24,7 +26,10 @@ export default function TopPanel({
           </CloseButton>
         )}
       </SearchRow>
-      <HubModalSelector />
+      <HubModalSelector
+        selectedModel={selectedHub}
+        onModelChange={onHubChange}
+      />
     </TopContainer>
   );
 }

--- a/src/pages/MakerPage/api/prompts.js
+++ b/src/pages/MakerPage/api/prompts.js
@@ -71,3 +71,39 @@ export const getGeneratedPrompts = async (params = {}) => {
   const response = await apiClient.get("/api/prompts", { params: queryParams });
   return response.data;
 };
+
+/**
+ * 내가 작성한 프롬프트를 조회합니다.
+ * @param {Object} params - 쿼리 파라미터
+ * @param {string} params.category - 카테고리 (선택, default: "전체")
+ * @param {string} params.visibility - 공개 여부 (선택, default: "all")
+ * @returns {Promise<Array>} 내가 작성한 프롬프트 목록
+ */
+export const getMyPrompts = async (params = {}) => {
+  const queryParams = {
+    category: params.category || "전체",
+    visibility: params.visibility || "all",
+    ...params,
+  };
+  const response = await apiClient.get("/api/prompts/me", {
+    params: queryParams,
+  });
+  return response.data;
+};
+
+/**
+ * 좋아요한 프롬프트를 조회합니다.
+ * @param {Object} params - 쿼리 파라미터
+ * @param {string} params.category - 카테고리 (선택, default: "전체")
+ * @returns {Promise<Array>} 좋아요한 프롬프트 목록
+ */
+export const getLikedPrompts = async (params = {}) => {
+  const queryParams = {
+    category: params.category || "전체",
+    ...params,
+  };
+  const response = await apiClient.get("/api/prompts/likes", {
+    params: queryParams,
+  });
+  return response.data;
+};


### PR DESCRIPTION
## 📝 PR 유형

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #167

## ✅ 작업 목록

메이커 내 허브 드롭다운 (내가 작성한 글/좋아요) 화면 및 API 연동

- [x] 기존에 있던 PromptCardDetail 재사용 (onBack props는 모든 허브에만 적용되게)
- [x] 내가 작성한 글/좋아요 api 연동 (propmts.js)

## 🍰 논의사항
메이커 내 허브에서 [내가 작성한 글], [좋아요]는 뒤로가기 버튼이 의미가 없어서 아예 없앴는데 괜찮을 지 

## 📷 ETC
<img width="1767" height="966" alt="image" src="https://github.com/user-attachments/assets/0adadec7-ec9d-42d5-b18f-3fbb2ba4f768" />

