### PR TITLE
170 feat historybar UI logic

### DIFF
--- a/src/pages/MakerPage/MakerPage.jsx
+++ b/src/pages/MakerPage/MakerPage.jsx
@@ -204,6 +204,9 @@ export default function MakerPage({ selectedPrompt = null }) {
         return;
       }
 
+      const titleToSave = promptTitle;
+      const contentToSave = promptContent;
+
       // 전송해야 할 로컬 이미지 파일들
       const newImages = attachedImages.filter(
         (img) => img.file && !img.isServerImage
@@ -267,14 +270,10 @@ export default function MakerPage({ selectedPrompt = null }) {
           // 서버에서 반환된 제목으로 업데이트 (필요한 경우)
         }
 
-        // 새로 업로드된 이미지가 있으면, 서버에서 반환된 URL로 변환
-        // TODO: 서버 응답에 images 배열이 포함되어 있다면 사용
-        // 현재는 기존 로직 유지 (서버에서 이미지 URL을 반환하지 않을 수 있음)
-
         // 이전 값 업데이트 (저장 성공 후)
         prevValuesRef.current = {
-          title: promptTitle,
-          content: promptContent,
+          title: titleToSave,
+          content: contentToSave,
           imageUrls: urlsToKeep,
           newImageCount: newImages.length,
         };
@@ -678,8 +677,8 @@ export default function MakerPage({ selectedPrompt = null }) {
           }
         }}
         onOpenResultPanel={() => {
-          // History가 있을 때만 ResultPanel 열기
-          if (historyItems.length > 0) {
+          // 히스토리 목록이 있거나 선택된 historyId가 있으면 열기
+          if (historyItems.length > 0 || currentHistoryId) {
             setIsResultPanelOpen(true);
           }
         }}

--- a/src/pages/MakerPage/ResultPanel/ResultPanel.jsx
+++ b/src/pages/MakerPage/ResultPanel/ResultPanel.jsx
@@ -79,16 +79,18 @@ export default function ResultPanel({
             </TabButton>
           </TabHeader>
 
-          {activeTab === "HISTORY" ? (
-            <HistoryBar
-              currentIndex={currentHistoryIndex}
-              totalCount={historyItems.length || 10}
-              historyItems={historyItems}
-              onItemClick={onHistoryItemClick}
-            />
-          ) : (
-            <ResultFeedback feedbackText={feedbackText} />
-          )}
+          <TabContentWrapper>
+            {activeTab === "HISTORY" ? (
+              <HistoryBar
+                currentIndex={currentHistoryIndex}
+                totalCount={historyItems.length || 10}
+                historyItems={historyItems}
+                onItemClick={onHistoryItemClick}
+              />
+            ) : (
+              <ResultFeedback feedbackText={feedbackText} />
+            )}
+          </TabContentWrapper>
         </BottomSection>
       </ResultContent>
     </ResultPanelWrapper>
@@ -129,11 +131,13 @@ const ResultPanelHeader = styled.div`
 const ResultContent = styled.div`
   flex: 1;
   overflow-y: auto;
-  padding: ${(props) => (props.$isExpanded ? "0" : "3rem")};
+  padding: ${(props) =>
+    props.$isExpanded ? "0" : "2.75rem 2.75rem 0 2.75rem"};
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 0;
   align-items: stretch;
+  justify-content: flex-end;
 `;
 
 const ResultDisplayWrapper = styled.div`
@@ -152,8 +156,19 @@ const BottomSection = styled.div`
   width: ${(props) => (props.$isExpanded ? "62rem" : "100%")};
   padding: ${(props) =>
     props.$isExpanded ? "1.75rem 0 1.75rem 5.625rem" : "0"};
+  padding-top: 3rem;
   box-sizing: border-box;
-  flex-shrink: 0;
+  flex: 0 0 auto;
+  align-items: flex-start;
+`;
+
+const TabContentWrapper = styled.div`
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 19rem; /* HISTORY와 FEEDBACK 높이를 동일하게 맞춤 */
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 `;
 
 const TabHeader = styled.div`

--- a/src/pages/MakerPage/shared/HistoryBar.jsx
+++ b/src/pages/MakerPage/shared/HistoryBar.jsx
@@ -126,32 +126,6 @@ const HistoryContainer = styled.div`
   position: relative;
 `;
 
-const HistoryHeader = styled.div`
-  display: flex;
-  align-items: baseline;
-  gap: 0;
-  margin-bottom: 0.625rem;
-  position: relative;
-`;
-
-const HistoryTitle = styled.h3`
-  font-family: "Pretendard Variable", sans-serif;
-  font-size: 1.4375rem; /* 23px */
-  font-weight: 700;
-  color: #000000;
-  margin: 0;
-  line-height: 1.2;
-`;
-
-const HistoryCount = styled.span`
-  font-family: "Pretendard Variable", sans-serif;
-  font-size: 1rem; /* 16px */
-  font-weight: 500;
-  color: #848484;
-  margin-left: 0.875rem; /* 14px to match 138px - 44px - 23px title width */
-  line-height: 1.2;
-`;
-
 const HistoryListWrapper = styled.div`
   display: flex;
   position: relative;
@@ -293,7 +267,7 @@ const HistoryList = styled.div`
   flex-direction: column;
   gap: 2.375rem;
   margin-left: 2.5rem;
-  width: 22.125rem;
+  width: 27.375rem;
   min-height: 18rem; /* 라인 높이와 기본 영역 맞추기 */
 `;
 

--- a/src/pages/MakerPage/shared/HistoryBar.jsx
+++ b/src/pages/MakerPage/shared/HistoryBar.jsx
@@ -162,7 +162,7 @@ const TopBlurOverlay = styled.div`
   right: 0;
   height: 3.125rem;
   background-color: #ffffff;
-  filter: blur(20px);
+  filter: blur(2rem);
   z-index: 10;
   pointer-events: none;
   margin-bottom: -3.125rem;

--- a/src/pages/MakerPage/shared/HistoryBar.jsx
+++ b/src/pages/MakerPage/shared/HistoryBar.jsx
@@ -69,7 +69,7 @@ export default function HistoryBar({
           >
             {hasScrollableContent && <TopBlurOverlay />}
             <TimelineContainer>
-              <TimelineLine $itemCount={historyItems.length} />
+              <TimelineLine $itemCount={historyItems.length || 1} />
               {historyItems.map((item, index) => (
                 <TimelineDot
                   key={`dot-${item.id || index}`}
@@ -162,7 +162,12 @@ const ScrollableArea = styled.div`
   position: relative;
   overflow-y: ${(props) => (props.$hasScrollableContent ? "auto" : "visible")};
   overflow-x: hidden;
-  max-height: ${(props) => (props.$hasScrollableContent ? "15rem" : "none")};
+  min-height: 18rem; /* 항목 수와 무관하게 세로선이 영역 전체를 차지하도록 */
+  /* 4개부터 스크롤: 4개 높이(≈19.125rem)까지만 보여주고 넘치면 스크롤 */
+  max-height: ${(props) =>
+    props.$hasScrollableContent
+      ? "calc((3rem + 2.375rem) * 3 + 3rem)"
+      : "18rem"};
   margin-left: 0;
   width: 100%;
   scroll-behavior: smooth;
@@ -235,8 +240,8 @@ const TimelineContainer = styled.div`
   position: absolute;
   left: 0;
   top: 0;
+  bottom: 0;
   width: 1.625rem; /* 26px */
-  height: auto;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -250,11 +255,12 @@ const TimelineLine = styled.div`
   transform: translateX(-50%);
   width: 0.125rem; /* 2px */
   height: ${(props) => {
-    // Calculate height using rem: (item height 3rem + gap 2.375rem) * (count - 1) + item height 3rem
     const itemHeight = 3; // 3rem
     const gap = 2.375; // 2.375rem
     const count = props.$itemCount || 1;
-    return `${(itemHeight + gap) * (count - 1) + itemHeight}rem`;
+    const calcHeight = (itemHeight + gap) * (count - 1) + itemHeight;
+    const minHeight = 18; // rem
+    return `max(${calcHeight}rem, ${minHeight}rem)`; // 아이템 높이 vs 최소 높이 중 큰 값
   }};
   background-color: #49d8ff;
   z-index: 0;
@@ -288,6 +294,7 @@ const HistoryList = styled.div`
   gap: 2.375rem;
   margin-left: 2.5rem;
   width: 22.125rem;
+  min-height: 18rem; /* 라인 높이와 기본 영역 맞추기 */
 `;
 
 const HistoryItem = styled.div`

--- a/src/pages/MakerPage/shared/ResultDisplay.jsx
+++ b/src/pages/MakerPage/shared/ResultDisplay.jsx
@@ -111,7 +111,7 @@ const DisplayContainer = styled.div`
   margin: ${(props) =>
     props.$isExpanded ? "0" : "0 auto"}; /* 확장 시 왼쪽 정렬, 기본은 가운데 */
   transition: width 0.3s ease, height 0.3s ease;
-  gap: 1rem;
+  gap: 2rem;
 `;
 
 const ResultSection = styled.div`
@@ -149,7 +149,7 @@ const TextContent = styled.div`
   letter-spacing: -0.0125rem; /* -0.475px */
   color: #000000;
   box-sizing: border-box;
-  padding: 1.75rem; /* 28px */
+  padding: 0;
   white-space: pre-wrap;
   word-wrap: break-word;
 

--- a/src/pages/MakerPage/shared/ResultFeedback.jsx
+++ b/src/pages/MakerPage/shared/ResultFeedback.jsx
@@ -19,6 +19,7 @@ const FeedbackContainer = styled.section`
   background-color: #e0f5ff;
   padding: 1rem;
   box-sizing: border-box;
+  display: block; /* 텍스트 길이에 따라 높이 자동 확장 */
 `;
 
 const FeedbackText = styled.p`


### PR DESCRIPTION
## 📝 PR 유형

- [ ] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [x] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #170

## ✅ 작업 목록
**1위) 히스토리바 전체 변경**
- [x] 히스토리 바 길게 표시 (현재 조금 잘림)
- 히스토리에 생성된 시간/NEW가 없음 → 히스토리 전체 조회 API에 createdAt 필드가 없어 오류 발생(회의 때 말씀드리고 고치기)

**2위) 히스토리/메이커 내 로직 변경**
- 마지막으로 사용자가 자동저장한 프롬프트 메이커를 나갔다가 들어왔을 때 처음 보이게 설정 중=> 히스토리는 가장 최근 결과를 가리키고 있어, 자동저장한 프롬프트와 최근 히스토리 사이 내용이 혼동될 수 있음
=> 개선방향이랑 기획이랑 상의 후 변경 (RUN할 경우, 최근의 결과텍스트가 Maker 홈에 보이기 때문에 혼동의 여지가 있음)

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
