### PR TITLE
fix: 타이틀 변경 감지가 되지 않아 자동저장이 안되는 문제 해결(props 추가 및 연결)

### DIFF
--- a/src/pages/MakerPage/MainPanel/MainPanel.jsx
+++ b/src/pages/MakerPage/MainPanel/MainPanel.jsx
@@ -11,6 +11,8 @@ export default function MainPanel({
   onToggleSidebar,
   promptContent,
   onPromptContentChange,
+  promptTitle,
+  onPromptTitleChange,
   attachedImages,
   onAttachedImagesChange,
   onUpgradeRequest,
@@ -43,7 +45,10 @@ export default function MainPanel({
       <ContentArea>
         <TopSection>
           <TitleAndControlRow>
-            <PromptTitleInput />
+            <PromptTitleInput
+              value={promptTitle}
+              onChange={onPromptTitleChange}
+            />
             {/* ResultPanel이 열려있거나 확장되었을 때 ControlBar 숨기기 */}
             {!isResultPanelOpen && !isResultPanelExpanded && (
               <ControlBar

--- a/src/pages/MakerPage/MainPanel/PromptTitleInput.jsx
+++ b/src/pages/MakerPage/MainPanel/PromptTitleInput.jsx
@@ -1,8 +1,7 @@
 import React, { useState, useRef, useLayoutEffect } from "react";
 import styled from "styled-components";
 
-export default function PromptTitleInput() {
-  const [title, setTitle] = useState("");
+export default function PromptTitleInput({ value = "", onChange }) {
   const [underlineWidth, setUnderlineWidth] = useState(0);
   const measureRef = useRef(null);
 
@@ -27,18 +26,18 @@ export default function PromptTitleInput() {
         window.removeEventListener("resize", updateWidth);
       }
     };
-  }, [title]);
+  }, [value]);
 
   return (
     <TitleInputWrapper>
       <MeasureText ref={measureRef}>
-        {title || "프롬프트 제목을 입력하세요."}
+        {value || "프롬프트 제목을 입력하세요."}
       </MeasureText>
       <TitleInput
         type="text"
         placeholder="프롬프트 제목을 입력하세요."
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
+        value={value}
+        onChange={(e) => onChange?.(e.target.value)}
       />
       <Underline $width={underlineWidth} />
     </TitleInputWrapper>


### PR DESCRIPTION
## 📝 PR 유형

- [ ] ✨ feat: 새로운 기능
- [x] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #173 

## ✅ 작업 목록

- [x] PromptTitleInput의 title을 state로 관리하고 있었음(문제) -> 상위 컴포넌트와 연결 X
- [x] state를 props로 바꾸고, 해당 변화를 감지하는 onChange props를 선언해 MainPanel과 연결

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
