### PR TITLE
177 fix makershellpage bugs

### DIFF
--- a/src/pages/MakerPage/MakerPageCard.jsx
+++ b/src/pages/MakerPage/MakerPageCard.jsx
@@ -127,7 +127,7 @@ const BackgroundOverlay = styled.div`
     rgba(9, 23, 43, 0.45) 100%
   );
   pointer-events: none;
-  z-index: 0;
+  z-index: 2;
 `;
 
 const HoverBackgroundOverlay = styled.div`
@@ -135,7 +135,7 @@ const HoverBackgroundOverlay = styled.div`
   inset: 0;
   background-color: rgba(0, 0, 0, 0.16); /* #00000029 16% 투명도 */
   pointer-events: none;
-  z-index: 2;
+  z-index: 3;
   transition: opacity 0.15s ease;
 `;
 
@@ -144,11 +144,6 @@ const ImageCard = styled(BaseCard)`
   background: ${({ $backgroundImage }) =>
     `url(${$backgroundImage}) center/cover no-repeat`};
   transition: transform 0.15s ease, box-shadow 0.15s ease;
-
-  & > *:not(${BackgroundOverlay}) {
-    position: relative;
-    z-index: 1;
-  }
 `;
 
 const DefaultCard = styled(BaseCard)`
@@ -187,6 +182,7 @@ const Description = styled.p`
   text-overflow: ellipsis;
   width: 100%;
   text-align: left;
+  z-index: 10;
 `;
 
 const FooterBase = styled.div`
@@ -212,6 +208,7 @@ const Title = styled.p`
   white-space: nowrap;
   width: 100%;
   text-align: left;
+  z-index: 10;
 `;
 
 const DeleteButton = styled.button`
@@ -225,7 +222,7 @@ const DeleteButton = styled.button`
   background-color: rgba(255, 255, 255, 0.9);
   color: #ffffff;
   cursor: pointer;
-  z-index: 15;
+  z-index: 20;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -258,7 +255,7 @@ const HoverOverlay = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 10;
+  z-index: 15;
   background-color: aquamarine;
   pointer-events: none;
 `;

--- a/src/pages/MakerPage/MakerShellPage.jsx
+++ b/src/pages/MakerPage/MakerShellPage.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
 import MakerPage from "./MakerPage";
 import MakerPageCard from "./MakerPageCard";
 import SearchInput from "./SidePanel/TopPanel/SearchInput";
@@ -18,6 +18,7 @@ const MAKER_NOT_FOUND_MESSAGE = "선택한 Maker를 찾을 수 없습니다.";
 
 export default function MakerShellPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const { makerId: makerIdParam } = useParams();
   const [makerView, setMakerView] = useState(RUN_STATE.RUN);
   const [makers, setMakers] = useState([]);
@@ -55,22 +56,26 @@ export default function MakerShellPage() {
       const normalized = makerList.map((maker) => {
         const isRun = makerView === RUN_STATE.RUN;
 
+        const safeContent = (maker.content || "").trim();
+        const safeResultText = (maker.resultText || "").trim();
+        const safeTitle = (maker.title || "").trim();
+
         // RUN일 때만 결과 이미지를 카드 썸네일로 사용
         const imageUrl =
           isRun && maker.resultType === "IMAGE" && maker.resultImageUrl
             ? maker.resultImageUrl
             : "";
 
-        // 리스트 카드에 보여줄 텍스트
+        // 리스트 카드에 보여줄 텍스트 (RUN에서 결과 텍스트가 비었으면 사용자가 작성한 content로 대체)
         const displayContent = isRun
-          ? maker.resultText || ""
-          : maker.content || "";
+          ? safeResultText || safeContent || "내용이 없습니다."
+          : safeContent || "내용이 없습니다.";
 
         return {
           makerId: maker.makerId,
-          title: maker.title || "",
+          title: safeTitle || "새로운 프롬프트",
           // 상세 페이지의 PromptEditor에 들어갈 사용자가 작성한 원본 텍스트
-          content: maker.content || "",
+          content: safeContent,
           // 리스트(카드)에서만 사용하는 표시용 텍스트
           displayContent,
           imageUrl,
@@ -94,6 +99,13 @@ export default function MakerShellPage() {
   useEffect(() => {
     fetchMakers();
   }, [fetchMakers, makerView]);
+
+  // 동일 경로로 돌아왔을 때도 최신 자동저장 내용을 반영하도록 재조회
+  useEffect(() => {
+    if (location.pathname.includes("/maker")) {
+      fetchMakers();
+    }
+  }, [location.pathname, fetchMakers]);
 
   const findMakerById = useCallback(
     (id) => {

--- a/src/pages/MakerPage/MakerShellPage.jsx
+++ b/src/pages/MakerPage/MakerShellPage.jsx
@@ -68,8 +68,8 @@ export default function MakerShellPage() {
 
         // 리스트 카드에 보여줄 텍스트 (RUN에서 결과 텍스트가 비었으면 사용자가 작성한 content로 대체)
         const displayContent = isRun
-          ? safeResultText || safeContent || "내용이 없습니다."
-          : safeContent || "내용이 없습니다.";
+          ? safeResultText || safeContent || ""
+          : safeContent || "";
 
         return {
           makerId: maker.makerId,

--- a/src/pages/MakerPage/MakerShellPage.jsx
+++ b/src/pages/MakerPage/MakerShellPage.jsx
@@ -371,6 +371,21 @@ export default function MakerShellPage() {
     return filteredMakers.slice(startIndex, endIndex);
   }, [filteredMakers, currentPage]);
 
+  const filledMakers = useMemo(() => {
+    const list = paginatedMakers;
+    const missing = CARDS_PER_PAGE - list.length;
+
+    if (missing <= 0) return list;
+
+    // placeholder 5개, 3개 등 자동 생성
+    const placeholders = Array.from({ length: missing }, (_, i) => ({
+      placeholder: true,
+      id: `placeholder-${i}`,
+    }));
+
+    return [...list, ...placeholders];
+  }, [paginatedMakers]);
+
   const handleSearchChange = useCallback((valueOrEvent) => {
     if (typeof valueOrEvent === "string") {
       setSearchKeyword(valueOrEvent);
@@ -487,16 +502,20 @@ export default function MakerShellPage() {
               ) : filteredMakers.length === 0 ? (
                 <InlineStatus>검색 결과가 없습니다.</InlineStatus>
               ) : (
-                paginatedMakers.map((prompt) => (
-                  <MakerPageCard
-                    key={prompt?.makerId}
-                    title={prompt.title}
-                    description={prompt.displayContent ?? prompt.content}
-                    imageUrl={prompt.imageUrl}
-                    onClick={() => handleSelectMaker(prompt?.makerId)}
-                    onDelete={() => handleDeleteMaker(prompt?.makerId)}
-                  />
-                ))
+                filledMakers.map((prompt) =>
+                  prompt.placeholder ? (
+                    <EmptyCard key={prompt.id} />
+                  ) : (
+                    <MakerPageCard
+                      key={prompt.makerId}
+                      title={prompt.title}
+                      description={prompt.displayContent ?? prompt.content}
+                      imageUrl={prompt.imageUrl}
+                      onClick={() => handleSelectMaker(prompt?.makerId)}
+                      onDelete={() => handleDeleteMaker(prompt?.makerId)}
+                    />
+                  )
+                )
               )}
             </CardGrid>
             {filteredMakers.length > 0 && (
@@ -733,4 +752,14 @@ const PageSeparator = styled.span`
 
 const TotalPage = styled.span`
   color: #a0a0a0;
+`;
+
+const EmptyCard = styled.div`
+  width: 100%;
+  aspect-ratio: 358 / 202;
+  border-radius: 1.1rem;
+  min-width: 12.25rem;
+  max-width: 22.375rem;
+  aspect-ratio: 358 / 202;
+  visibility: hidden; /* 공간은 유지, 보이진 않음 */
 `;


### PR DESCRIPTION
## 📝 PR 유형

- [ ] ✨ feat: 새로운 기능
- [x] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #177

## ✅ 작업 목록

- [x]  메이커 초기화면(홈)에서 이미지가 들어간 MakerCard에서 삭제 버튼 UI 깨지는 문제 해결 (z-index)
- [x]  프롬프트 작성 → MakerShellPage 으로 가면 빈 상자가 뜨는 버그 (재렌더링)
- [x] MakerShellPage 내 4개가 떠도 9개(3x3) 의 틀을 유지하게 수정 (가상 placeholder를 기존 카드의 layout과 동일하게 설정하여 hidden)

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
