### PR TITLE
feat: 사용자가 제목 설정하기 전까지는 placeholder 표시 + 제목 미설정 및 빈 문자열 입력 시, 백엔드 def…

### DIFF
--- a/src/pages/MakerPage/MainPanel/PromptTitleInput.jsx
+++ b/src/pages/MakerPage/MainPanel/PromptTitleInput.jsx
@@ -1,9 +1,34 @@
-import React, { useState, useRef, useLayoutEffect } from "react";
+import React, { useState, useRef, useLayoutEffect, useEffect } from "react";
 import styled from "styled-components";
 
 export default function PromptTitleInput({ value = "", onChange }) {
   const [underlineWidth, setUnderlineWidth] = useState(0);
   const measureRef = useRef(null);
+
+  // "새로운 프롬프트"인지 확인
+  const isDefaultTitle = value === "새로운 프롬프트";
+
+  // 내부 input 값: "새로운 프롬프트"면 빈 문자열, 아니면 실제 값
+  const [inputValue, setInputValue] = useState(isDefaultTitle ? "" : value);
+  const prevValueRef = useRef(value);
+  const isUserTypingRef = useRef(false);
+
+  // value prop이 외부에서 변경될 때만 inputValue 동기화
+  useEffect(() => {
+    // value가 실제로 변경되었고, 사용자가 입력 중이 아닐 때만 동기화
+    if (prevValueRef.current !== value && !isUserTypingRef.current) {
+      if (isDefaultTitle) {
+        // "새로운 프롬프트"로 변경되면 빈 문자열로
+        setInputValue("");
+      } else {
+        // "새로운 프롬프트"가 아니면 value로 동기화
+        setInputValue(value);
+      }
+      prevValueRef.current = value;
+    }
+    // 동기화 후 사용자 입력 플래그 리셋
+    isUserTypingRef.current = false;
+  }, [value, isDefaultTitle]);
 
   useLayoutEffect(() => {
     const updateWidth = () => {
@@ -26,18 +51,27 @@ export default function PromptTitleInput({ value = "", onChange }) {
         window.removeEventListener("resize", updateWidth);
       }
     };
-  }, [value]);
+  }, [inputValue, isDefaultTitle]);
+
+  const handleChange = (e) => {
+    const newValue = e.target.value;
+    setInputValue(newValue);
+    // 사용자가 입력하는 순간 바로 onChange 호출
+    isUserTypingRef.current = true;
+    onChange?.(newValue);
+  };
+
+  // MeasureText에 표시할 텍스트: inputValue가 있으면 inputValue, 없으면 placeholder
+  const displayText = inputValue || "프롬프트 제목을 입력하세요.";
 
   return (
     <TitleInputWrapper>
-      <MeasureText ref={measureRef}>
-        {value || "프롬프트 제목을 입력하세요."}
-      </MeasureText>
+      <MeasureText ref={measureRef}>{displayText}</MeasureText>
       <TitleInput
         type="text"
         placeholder="프롬프트 제목을 입력하세요."
-        value={value}
-        onChange={(e) => onChange?.(e.target.value)}
+        value={inputValue}
+        onChange={handleChange}
       />
       <Underline $width={underlineWidth} />
     </TitleInputWrapper>


### PR DESCRIPTION

## 📝 PR 유형

- [ ] ✨ feat: 새로운 기능
- [x] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #182 

## ✅ 작업 목록

[로직 변경]

1. BE에서 내려온 title이 "새로운 프롬프트"인 경우
    → input에는 빈 값("")으로 렌더
    → placeholder 노출
    
2. 사용자가 title을 입력함
    → 그 값을 즉시 BE로 업데이트
    
3. 사용자가 끝까지 title을 입력하지 않음
    → DB에는 "새로운 프롬프트"가 남음
- [x] useRef로 감지 전/감지 후/입력을 감지하는 플래그로 나누어 조건부로 처리
- [x] 사용자가 title을 입력하기 전까지는 placeholder에서 바로 제목을 입력할 수 있고, 빈 문자열이나 아무것도 입력하지 않았을 때 백엔드 default값인 "새로운 프롬프트"로 표시

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC

<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
